### PR TITLE
Update Invariant-mass-histogram.ipynb

### DIFF
--- a/Examples/Invariant-mass-histogram.ipynb
+++ b/Examples/Invariant-mass-histogram.ipynb
@@ -178,7 +178,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Enter the amount of envents wanted: 8000\n",
+      "Enter the amount of events wanted: 8000\n",
       "\n",
       " You selected 8000 invariant mass values from the whole data.\n"
      ]


### PR DESCRIPTION
just fixed a typo: "envent" should be "event"